### PR TITLE
fix: improve responsive layout on auth pages

### DIFF
--- a/src/app/ui/views/auth/forgot-password/forgot-password.html
+++ b/src/app/ui/views/auth/forgot-password/forgot-password.html
@@ -2,23 +2,16 @@
   class="px-2 sm:px-8 py-20 md:px-12 lg:px-20 flex items-center justify-center backdrop-blur-3xl bg-cover! bg-center! bg-no-repeat! min-h-screen"
   style="background-image: url('/assets/images/background.jpeg')">
   <div class="w-full flex flex-col items-center justify-center">
-    <div class="w-[95%] sm:w-[400px]">
-      <div
-        class="backdrop-blur-2xl bg-white/10 py-12 px-4 sm:px-10 rounded-2xl">
+    <div class="w-[98%] sm:w-[90%] md:w-[80%] lg:w-[50%] xl:w-[40%] 2xl:w-[30%]">
+      <div class="backdrop-blur-2xl bg-white/10 py-12 px-4 sm:px-10 rounded-2xl">
         <div class="text-center mb-8">
-          <div
-            class="text-surface-100 dark:text-surface-0 text-3xl font-medium mb-4">
-            Bem vindo a IPR
-          </div>
-          <span class="text-surface-100 dark:text-surface-0 text-xl">Recuperar
-            senha</span>
+          <div class="text-surface-100 dark:text-surface-0 text-3xl font-medium mb-4">Bem vindo a IPR</div>
+          <span class="text-surface-100 dark:text-surface-0 text-xl">Recuperar senha</span>
         </div>
 
         <form [formGroup]="forgotPasswordForm">
           <div class="my-4">
-            <label
-              for="emailField"
-              class="block text-surface-100 dark:text-surface-0 text-xl font-medium mb-2">Email</label>
+            <label for="emailField" class="block text-surface-100 dark:text-surface-0 text-xl font-medium mb-2">Email</label>
             <input
               pInputText
               id="emailField"
@@ -27,20 +20,17 @@
               class="w-full mb-2"
               formControlName="email" />
 
-            <app-custom-validation-message id="emailErrorMessage"
-              controlName="email" />
+            <app-custom-validation-message id="emailErrorMessage" controlName="email" />
           </div>
 
           <div class="flex items-center justify-end mt-2 mb-8 gap-8">
             <span
               routerLink="/login"
-              class="text-sm sm:text-base font-medium hover:underline no-underline ml-2 text-right cursor-pointer text-primary">Login</span>
+              class="text-sm sm:text-base font-medium hover:underline no-underline ml-2 text-right cursor-pointer text-primary"
+              >Login</span
+            >
           </div>
-          <p-button
-            (click)="forgotPasswordHandler()"
-            id="forgotPasswordButton"
-            label="Lembrar"
-            styleClass="w-full"></p-button>
+          <p-button (click)="forgotPasswordHandler()" id="forgotPasswordButton" label="Lembrar" styleClass="w-full"></p-button>
         </form>
       </div>
     </div>

--- a/src/app/ui/views/auth/login/login.html
+++ b/src/app/ui/views/auth/login/login.html
@@ -2,7 +2,7 @@
   class="px-2 sm:px-8 py-20 md:px-12 lg:px-20 flex items-center justify-center backdrop-blur-3xl bg-cover! bg-center! bg-no-repeat! min-h-screen"
   style="background-image: url('assets/images/background.jpeg')">
   <div class="w-full flex flex-col items-center justify-center">
-    <div class="w-[95%] sm:w-100">
+    <div class="w-[98%] sm:w-[90%] md:w-[80%] lg:w-[50%] xl:w-[40%] 2xl:w-[30%]">
       <div class="backdrop-blur-2xl bg-white/10 py-12 px-4 sm:px-10 rounded-2xl">
         <div class="text-center mb-8">
           <div class="text-surface-100 dark:text-surface-0 text-3xl font-medium mb-4">Bem vindo a IPR</div>

--- a/src/app/ui/views/auth/reset-password/reset-password.html
+++ b/src/app/ui/views/auth/reset-password/reset-password.html
@@ -2,23 +2,17 @@
   class="px-2 sm:px-8 py-20 md:px-12 lg:px-20 flex items-center justify-center backdrop-blur-3xl bg-cover! bg-center! bg-no-repeat! min-h-screen"
   style="background-image: url('/assets/images/background.jpeg')">
   <div class="w-full flex flex-col items-center justify-center">
-    <div class="w-[95%] sm:w-[400px]">
-      <div
-        class="backdrop-blur-2xl bg-white/10 py-12 px-4 sm:px-10 rounded-2xl">
+    <div class="w-[98%] sm:w-[90%] md:w-[80%] lg:w-[50%] xl:w-[40%] 2xl:w-[30%]">
+      <div class="backdrop-blur-2xl bg-white/10 py-12 px-4 sm:px-10 rounded-2xl">
         <div class="text-center mb-8">
-          <div
-            class="text-surface-900 dark:text-surface-0 text-3xl font-medium mb-4">
-            Bem vindo a IPR
-          </div>
+          <div class="text-surface-900 dark:text-surface-0 text-3xl font-medium mb-4">Bem vindo a IPR</div>
           <span class="text-muted-color font-medium">Gerar nova Senha</span>
         </div>
 
         <form [formGroup]="resetPasswordForm">
           <!-- Password -->
           <div class="my-4">
-            <label
-              for="passwordField"
-              class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Senha</label>
+            <label for="passwordField" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Senha</label>
             <p-password
               id="passwordField"
               formControlName="password"
@@ -28,22 +22,17 @@
               [fluid]="true"
               [feedback]="false"></p-password>
 
-            <app-custom-validation-message
-              id="passwordErrorMessage"
-              controlName="password"
-              [minLength]="3" />
+            <app-custom-validation-message id="passwordErrorMessage" controlName="password" [minLength]="3" />
           </div>
 
           <div class="flex items-center justify-end mt-2 mb-8 gap-8">
             <span
               routerLink="/login"
-              class="text-sm sm:text-base font-medium hover:underline no-underline ml-2 text-right cursor-pointer text-primary">Login</span>
+              class="text-sm sm:text-base font-medium hover:underline no-underline ml-2 text-right cursor-pointer text-primary"
+              >Login</span
+            >
           </div>
-          <p-button
-            (click)="resetPasswordHandler()"
-            id="resetPasswordButton"
-            label="Gerar"
-            styleClass="w-full"></p-button>
+          <p-button (click)="resetPasswordHandler()" id="resetPasswordButton" label="Gerar" styleClass="w-full"></p-button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
This PR improves the responsive layout on auth pages (forgot-password, login, reset-password) by updating the container width classes to use more responsive breakpoints.